### PR TITLE
Ενημέρωση ωρολόγιου προγράμματος Β' Εξαμήνου

### DIFF
--- a/_timetables/sem_b.md
+++ b/_timetables/sem_b.md
@@ -6,101 +6,123 @@ timetable:
   - day: "Δευτέρα"
     time: 9
     course: theory-of-propability 
-    author: alex
-    location: "Εργαστήριο Γαληνός"
+    author: avlon
+    location: "Aμφιθέατρο 1"
   - day: "Δευτέρα"
     time: 11
-    course: theory-of-propability
-    author: avlon
-    location: "Αμφιθέατρο 2"
+    course: applied-programming-python
+    author: alex
+    location: "Εργαστήριο Γαληνός"
   - day: "Δευτέρα"
     time: 15
     course: data-structures
     author: "Α. Σωτηροπούλου"
-    location: "Εργαστήριο Γαληνός"
+    location: "Αμφιθέατρο 1"
   - day: "Δευτέρα"
     time: 17
-    course: data-structures
-    author: "Β. Καρυώτης"
-    location: "Αμφιθέατρο 1"
+    course: computer-programming
+    author: "Κ. Σκιαδόπουλος"
+    location: "Εργαστήριο Γαληνός"
+  - day: "Δευτέρα"
+    time: 19
+    course: applied-programming-python
+    author: "Δ Μουρατίδη"
+    location: "Εργαστήριο Γαληνός"
+
     
   - day: "Τρίτη"
-    time: 11
-    course: discrete-mathematics
-    author: vlamos
-    location: "Αμφιθέατρο 1"
-  - day: "Τρίτη"
-    time: 13
-    course: computer-programming
-    author: andronikos
-    location: "Εργαστήριο Γαληνός"
-  - day: "Τρίτη"
-    time: 15
-    course: computer-programming
-    author: mistral
-    location: "Εργαστήριο Γαληνός"
-
-  - day: "Τετάρτη"
     time: 9
-    course: discrete-mathematics
-    author: vlamos
-    location: "Αμφιθέατρο 1"
-  - day: "Τετάρτη"
+    course: theory-of-propability
+    author: alex
+    location: "Εργαστήριο Γαληνός"  
+  - day: "Τρίτη"
     time: 11
     course: theory-of-propability
     author: alex
     location: "Εργαστήριο Γαληνός"
-  - day: "Τετάρτη"
+  - day: "Τρίτη"
     time: 13
-    course: computer-programming
-    author: andronikos
-    location: "Εργαστήριο Γαληνός"
-  - day: "Τετάρτη"
-    time: 15
-    course: ba
-    author: doukakis
-    location: "Αμφιθέατρο 2"
-
-  - day: "Πέμπτη"
-    time: 13
-    course: discrete-mathematics
+    course: discrete-mathematics 
     author: "Γ. Κατωμέρης"
-    location: "Εργαστήριο Γαληνός"
-  - day: "Πέμπτη"
+    location: "Αίθουσα 3"
+  - day: "Τρίτη"
     time: 15
     course: ba
     author: doukakis
     location: "Αμφιθέατρο 2"
-  - day: "Πέμπτη"
+  - day: "Τρίτη"
     time: 17
     course: computer-programming
-    author: andronikos
-    location: "Εργαστήριο Γαληνός"
-  - day: "Πέμπτη"
-    time: 19
-    course: computer-programming
-    author: andronikos
+    author: "Κ. Σκιαδόπουλος"
     location: "Αμφιθέατρο 1"
   
-  - day: "Παρασκευή"
+
+  - day: "Τετάρτη"
     time: 11
-    course: theory-of-propability
+    course: probability-theory
     author: avlon
-    location: "Αμφιθέατρο 2"
-  - day: "Παρασκευή"
+    location: "Αμφιθέατρο 1"
+  - day: "Τετάρτη"
     time: 13
     course: discrete-mathematics
-    author: "Γ. Κατωμέρης"
-    location: "Εργαστήριο Γαληνός"
-  - day: "Παρασκευή"
+    author: vlamos
+    location: "Αμφιθέατρο 1"
+  - day: "Τετάρτη"
     time: 15
-    course: "Αγγλικά ΙΙ"
-    author: "Σ. Κοζομπόλης"
-    location: "Αίθουσα 1"
-  - day: "Παρασκευή"
+    course: ba
+    author: doukakis
+    location: "Αμφιθέατρο 1"
+  - day: "Τετάρτη"
     time: 17
     course: data-structures
     author: "Α. Σωτηροπούλου"
+    location: "Αίθουσα 3"
+  - day: "Τετάρτη"
+    time: 19
+    course: computer-programming
+    author: "Γ. Αλεξανδρίδης"
     location: "Εργαστήριο Γαληνός"
+
+  - day: "Πέμπτη"
+    time: 11
+    course: discrete-mathematics
+    author: vlamos
+    location: "Αιθουσα 3"
+  - day: "Πέμπτη"
+    time: 15
+    course: data-structures
+    author: "Α. Σωτηροπούλου"
+    location: "Αμφιθέατρο 1"
+  - day: "Πέμπτη"
+    time: 17
+    course: applied-programming-python
+    author: karydis
+    location: "Αιθουσα 1"
+  - day: "Πέμπτη"
+    time: 19
+    course: "Αγγλικά 2" 
+    author: "Ε. Μωραϊτη"
+    location: "Αίθουσα 1"
+  
+  - day: "Παρασκευή"
+    time: 13
+    course: discrete-mathematics
+    author: "Γ. Κατωμέρης"
+    location: "Αμφιθέατρο 1"
+  - day: "Παρασκευή"
+    time: 15
+    course: applied-programming-python
+    author: "Δ. Αλεξανδράκης"
+    location: "Εργαστήριο Γαληνός"
+  - day: "Παρασκευή"
+    time: 17
+    course: applied-programming-python
+    author: "Δ. Αλεξανδράκης"
+    location: "Εργαστήριο Γαληνός"
+  - day: "Παρασκευή"
+    time: 19
+    course: "Αγγλικά 2" 
+    author: "Ε. Μωραϊτη"
+    location: "Αίθουσα 1"
 ---
 

--- a/_timetables/sem_b.md
+++ b/_timetables/sem_b.md
@@ -28,8 +28,6 @@ timetable:
     course: applied-programming-python
     author: "Δ Μουρατίδη"
     location: "Εργαστήριο Γαληνός"
-    author "Δ Μουρατίδη"
-    location: "Εργαστήριο Γαληνός"
 
     
   - day: "Τρίτη"
@@ -127,4 +125,3 @@ timetable:
     author: "Ε. Μωραϊτη"
     location: "Αίθουσα 1"
 ---
-


### PR DESCRIPTION
### Σχετικό Issue 235
closes ioniodi/sitegr#235

### Συνεργάτες που θα κάνουν σχόλια ή θα αξιολογήσουν τις αλλαγές: : @p17papa @axilleasmandravelis

### Προτεινόμενες Αλλαγές
- Ενημερώθηκε το all_collections/_timetable/sem_b.md με το πρόγραμμα του ακαδημαϊκού έτους 2021-2022 που ανακοινώθηκε 7 Μαρτίου 2022 και μπορείτε να δείτε την ενημέρωση live [εδώ](https://relaxed-golick-9a2890.netlify.app/timetables/sem_b/)
- Το pulll request πραγματοποιείται εδώ καθώς στο sitegr δεν έγινε καμία αλλαγή (πέραν του συγχρονισμού με το submodule)


### Υπενθυμίσεις
- [x] Έχω ανοίξει από πριν issue για τον καλό συντονισμό του project, το οποίο έχει πάρει το πράσινο φως με την αντίστοιχη ετικέτα
- [x] Έχω ενημερώσει το issueNo παραπάνω με τον αριθμό του αντίστοιχου θέματος, ώστε να κλείσει αυτόματα με την αποδοχή αυτού του αιτήματος
- [x] Έχω δημιουργήσει branch για τις αλλαγές
