### PR TITLE
Update compilers.md

### DIFF
--- a/_courses/compilers.md
+++ b/_courses/compilers.md
@@ -5,7 +5,7 @@ author: mistral
 excerpt: "Εισαγωγή στη μεταγλώττιση των προγραμμάτων. Γλώσσες γενικού σκοπού και ειδικές γλώσσες πεδίου (domain specific languages – DSLs). Λεκτική ανάλυση και εξαγωγή συμβόλων από πηγαίο κώδικα. Κανονικές Εκφράσεις και η πρακτική εφαρμογή τους. Αλγόριθμοι συντακτικής ανάλυσης. Πρακτική συντακτική ανάλυση top-down. Parsing Expression Grammars (PEGs). Πίνακες συμβόλων και ενδιάμεσος κώδικας. Εργαλεία μεταγλώττισης: διερμηνευτές (interpreters), συμβολομεταφραστές (assemblers), συνδέτες (linkers) και φορτωτές (loaders)."
 uri: "https://opencourses.ionio.gr/courses/DDI154/"
 code: ΗΥ150
-semester: 6
+semester: 8
 type: "Ο"
 hours: 4
 extra: 2E


### PR DESCRIPTION
### Το μάθημα μεταγλωττιστές βρίσκεται σε λάθος εξάμηνο
closes [#281](https://github.com/ioniodi/sitegr/issues/281)

### Σχετικό Pull Request
Σύνδεσμος σε σχετικό Pull Request στο sitegr που έχετε στείλει και πρέπει να επεξεργαστούμε σε συνδυασμό με αυτό εδώ

### Συνεργάτες  
@u2nmd, @vasiliskampani



### Προτεινόμενες Αλλαγές
-- Το μάθημα βρίσκεται πλέον στο σωστό εξάμηνο στις "Σπουδές"

-- Στα χαρακτηριστικά του μαθήματος βλέπουμε ότι υπάρχει πλέον το σωστό εξάμηνο  

[To link  για το demo site](https://darling-gingersnap-e29670.netlify.app/courses/compilers/)

### Υπενθυμίσεις
- [x] Έχω ανοίξει από πριν issue για τον καλό συντονισμό του project, το οποίο έχει πάρει το πράσινο φως με την αντίστοιχη ετικέτα
- [x] Έχω ενημερώσει το issueNo παραπάνω με τον αριθμό του αντίστοιχου θέματος, ώστε να κλείσει αυτόματα με την αποδοχή αυτού του αιτήματος
- [x] Έχω δημιουργήσει branch για τις αλλαγές και σας δίνω σύνδεσμο για την αλλαγή στο δικό μου netlify
