### PR TITLE
 Προσθήκη ανακοίνωσης "Ionian Wikithon 2022, 14 & 20 Μαΐου, Εργαστήριο Γαληνός, Τμήμα Πληροφορικής"

### DIFF
--- a/_posts/2022-05-09-ionian-wikithon-2022-14-20-maiou-ergastirio-galinos-tmhma-plhroforikis.md
+++ b/_posts/2022-05-09-ionian-wikithon-2022-14-20-maiou-ergastirio-galinos-tmhma-plhroforikis.md
@@ -1,0 +1,46 @@
+---
+ref: Ionian Wikithon 2022
+title: "Ανακοίνωση για το Ionian Wikithon 2022, 14 & 20 Μαΐου, Εργαστήριο Γαληνός, Τμήμα Πληροφορικής"
+excerpt: "Το Εργαστήριο Δικτύων, Πολυμέσων και Ασφάλειας Συστημάτων (NMSLab) του Τμήματος Πληροφορικής του Ιονίου Πανεπιστημίου σε συνεργασία με το Wikimedia Community User Group Greece και την υποστήριξη του Ionian IEEE SB διοργανώνει το Ionian Wikithon 2022, ένα Wikimedia prehackathon event."
+tags:  
+ - Γενικές Ανακοινώσεις
+ - Γενικές Εκδηλώσεις
+ - Εκπαιδευτικές Δράσεις
+categories:
+ - Σπουδές
+---
+
+Το Εργαστήριο Δικτύων, Πολυμέσων και Ασφάλειας Συστημάτων (NMSLab) του Τμήματος Πληροφορικής του Ιονίου Πανεπιστημίου σε συνεργασία με το Wikimedia Community User Group Greece και την υποστήριξη του Ionian IEEE SB διοργανώνει το Ionian Wikithon 2022, ένα Wikimedia prehackathon event.
+
+Το Wikimedia Hackathon είναι η ετήσια συνάντηση προγραμματιστών από όλο τον κόσμο που θέλουν να γνωρίσουν και να βελτιώσουν τον κώδικα της Βικιπαίδειας και τον αδελφών της εγχειρημάτων, κυρίως την πλατφόρμα MediaWiki στην οποία βασίζονται. Παράλληλα με το Wikimedia Hackathon κάθε χρόνο πραγματοποιούνται, σε όλον τον κόσμο, μία σειρά από prehackathons όπου συμμετέχουν προγραμματιστές και κυρίως φοιτητές.
+
+ 
+
+Ionian Wikithon - Σάββατο 14 Μαΐου 2022
+
+11:30 – 21:00
+
+Εργαστήριο Γαληνός, Πλατεία Τσιριγώτη 7
+
+ 
+
+Wikimedia Hackathon - Παρασκευή 20 Μαΐου 2022
+
+17:30-21:00
+
+Εργαστήριο Γαληνός, Πλατεία Τσιριγώτη 7
+
+ 
+Στο συνημμένο έγγραφο θα βρείτε το αναλυτικό πρόγραμμα όλων των εκδηλώσεων.
+ 
+Φόρμα συμμετοχής:
+ 
+https://forms.gle/LxFwHTfcqx3rMZHM9 
+ 
+ 
+Περισσότερες πληροφορίες επίσης εδώ: https://linktr.ee/ionian_wikithon
+ 
+ 
+Σας περιμένουμε!!
+
+#IonianWikithon #preHackathonCorfu #Wikithon #IonianUniversity #WikimediaGreece #WikimediaHackathon


### PR DESCRIPTION


### Σχετικό Issue
closes #[404](https://github.com/ioniodi/sitegr/issues/404)

 
### Συνεργάτες 

@vivikara @alexpoulis 

### Προτεινόμενες Αλλαγές
-- Προσθήκη ανακοίνωσης "Ionian Wikithon 2022, 14 & 20 Μαΐου, Εργαστήριο Γαληνός, Τμήμα Πληροφορικής"

-- [Demo](https://62816e1688893004df0823ad--reliable-toffee-4628a4.netlify.app/posts/2022/05/09/ionian-wikithon-2022-14-20-maiou-ergastirio-galinos-tmhma-plhroforikis/)

..

### Υπενθυμίσεις
- [X] Έχω ανοίξει από πριν issue για τον καλό συντονισμό του project, το οποίο έχει πάρει το πράσινο φως με την αντίστοιχη ετικέτα
- [X] Έχω ενημερώσει το issueNo παραπάνω με τον αριθμό του αντίστοιχου θέματος, ώστε να κλείσει αυτόματα με την αποδοχή αυτού του αιτήματος
- [X] Έχω δημιουργήσει branch για τις αλλαγές και σας δίνω σύνδεσμο για την αλλαγή στο δικό μου netlify
